### PR TITLE
fix bug in standardResponse() method in ApiController

### DIFF
--- a/src/Http/Controllers/ApiController.php
+++ b/src/Http/Controllers/ApiController.php
@@ -13,6 +13,7 @@ use Illuminate\Foundation\Bus\DispatchesJobs;
 use Illuminate\Foundation\Validation\ValidatesRequests;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller as BaseController;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Str;
 use Luezoid\Laravelcore\Constants\ErrorConstants;
@@ -124,7 +125,7 @@ abstract class ApiController extends BaseController
         }
         return response()->json([
             "message" => $message,
-            "data" => $data && method_exists($data, 'toArray') ? $data->toArray() : $data,
+            "data" => $data && ($data instanceof Collection) ? $data->toArray() : $data,
             "type" => $type
         ], $httpCode);
     }


### PR DESCRIPTION
fix: `method_exists(): Argument #1 ($object_or_class) must be of type object|string, array given`